### PR TITLE
翻译hardware-crazyflie2

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,8 +1,8 @@
 # Summary
 
-* [Introduction](README.md)
-* Getting Started
-  * [Initial Configuration](starting-initial-config.md)
+* [介绍](README.md)
+* 入门
+  * [初始配置](starting-initial-config.md)
   * [Toolchain Installation](starting-installing.md)
     * [Mac OS](starting-installing-mac.md)
     * [Linux](starting-installing-linux.md)
@@ -61,7 +61,7 @@
     * [QAV-R](qav-r.md)
   * [Planes](airframes-plane.md)
     * [Wing Wing Z-84](airframes-plane-wing-z-84.md)
-  * [VTOL](airframes-vtol.md)
+  * [垂直起降VTOL](airframes-vtol.md)
     * [VTOL Testing](airframes-vtol-testing.md)
     * [TBS Caipiroshka](airframes-vtol-caipiroshka.md)
   * [Boats, Submarines, Blimps, Rovers](airframes-experimental.md)
@@ -72,7 +72,7 @@
 * [Robotics using ROS](robotics-using-ros.md)
   * [Offboard Control from Linux](offboard-control.md)
   * [ROS Installation on RPi](ros-raspberrypi-installation.md)
-  * [MAVROS \(MAVLink on ROS\)](ros-mavros-installation.md)
+  * [MAVROS \(基于ROS的MAVLink\)](ros-mavros-installation.md)
   * [MAVROS offboard example](ros-mavros-offboard.md)
   * [External Position Estimation](external-position.md)
   * [Gazebo Octomap](simulation-gazebo-octomap.md)
@@ -89,8 +89,8 @@
 * Debugging and Advanced Topics
 
   * [FAQ](advanced-faq.md)
-  * [System Console](advanced-system-console.md)
-  * [System Boot](advanced-system-startup.md)
+  * [系统控制台](advanced-system-console.md)
+  * [系统启动](advanced-system-startup.md)
   * [Parameters & Configs](advanced-configurations.md)
   * [Autopilot Debugging](advanced-gdb-debugging.md)
   * [Simulation Debugging](simulation-debugging.md)
@@ -99,7 +99,7 @@
   * [Camera Trigger](advanced-camera-trigger.md)
   * [Logging](advanced-logging.md)
   * [Flight Log Analysis](flight_log_analysis.md)
-  * [EKF Log Replay](ekf2_log_replay.md)
+  * [EKF飞行记录回放](ekf2_log_replay.md)
   * [System-wide Replay](advanced-replay.md)
   * [Installing driver for Intel RealSense R200](advanced-realsense_intel.md)
   * [Parrot Bebop](advanced-bebop.md)

--- a/advanced-system-console.md
+++ b/advanced-system-console.md
@@ -1,75 +1,77 @@
-# PX4 System Console
+# PX4 System Console(系统控制台)
 
-The system console allows low-level access to the system, debug output and analysis of the system boot process. The most convenient way to connect it is by using a [Dronecode probe](http://nicadrone.com/index.php?id_product=65&controller=product), but a plain FTDI cable can be used as well.
+System Console(系统控制台)允许访问系统底层，调试输出和分析系统启动流程。访问System Console最快捷的方式是使用 [Dronecode probe](http://nicadrone.com/index.php?id_product=65&controller=product), 但是常见的FTDI连线也是可以的。
 
 ## System Console vs. Shell
 
-There are multiple shells, but only one console: The system console is the location where all boot output (and applications auto-started on boot) is printed.
 
-  * System console (first shell): Hardware serial port
-  * Additional shells: Pixhawk on USB (e.g. lists as /dev/tty.usbmodem1 on Mac OS)
+有好多种shell，但只有一个Console：系统控制台，它是打印所有引导输出（和引导中自动启动的应用程序）的位置。（可以理解为系统控制台是多个shell中唯一一个打印所有引导输出的shell）
 
-> **Info**
-> USB shell: To just run a few quick commands or test an application connecting to the USB
-> shell is sufficient. The Mavlink shell can be used for this, see below.
-> The hardware serial console is only needed for boot debugging or when USB should be used
-> for MAVLink to connect a [GCS](qgroundcontrol-intro.md).
+The system console is the location where all boot output (and applications auto-started on boot) is printed.
 
-## Snapdragon Flight: Wiring the Console
+  * System console（第一shell）：硬件串口
+  * 其他shell : 连接至USB的Pixhawk(如Mac OS下显示为 /dev/tty.usbmodem1)
 
-The developer kit comes with a breakout board with three pins to access the console. Connect the bundled FTDI cable to the header and the breakout board to the expansion connector.
+> **info**
+> USB shell: 如果只是运行几个简单的命令或测试应用程序，连接到USB shell就足够了。
+>MAVLink shell可以这么使用，参照下文。
+>只有在调试启动流程或USB接口已被用于MAVlink连接地面站[GCS](qgroundcontrol-intro.md)的时候，才需要使用硬件串口console。
 
-## Pixracer / Pixhawk v3: Wiring the Console
+## Snapdragon Flight : Console接线
 
-Connect the 6-pos JST SH 1:1 cable to the Dronecode probe or connect the individual pins of the cable to a FTDI cable like this:
+Snapdragon Flight（骁龙开发平台）开发人员套件里面包含了一个3引脚的接线板，它可以用于访问console。 将附带的FTDI线连接到接头，并将接线板连接到扩展连接器。
 
-| Pixracer / Pixhawk v3  |         | FTDI    |        |
-| -- | -- | -- | -- |
-|1         | +5V (red)     |         | N/C    |
-|2         | UART7 Tx      | 5       | FTDI RX (yellow)  |
-|3         | UART7 Rx      | 4       | FTDI TX (orange)  |
-|4         | SWDIO      |         | N/C   |
-|5         | SWCLK      |         | N/C   |
-|6         | GND     | 1       | FTDI GND (black)   |
+## Pixracer / Pixhawk v3: Console接线
 
-## Pixhawk v1: Wiring the Console
+将6P JST SH 1：1线连接到Dronecode Probe，或者将连接线的每个引脚按照如下所示连接到FTDI线上：
 
-The system console can be accessed through the Dronecode probe or an FTDI cable. Both options are explained in the section below.
+| Pixracer / Pixhawk v3 |           | FTDI |              |
+| --------------------- | --------- | ---- | ------------ |
+| 1                     | +5V (红)  |      | N/C          |
+| 2                     | UART7 Tx  | 5    | FTDI RX (黄) |
+| 3                     | UART7 Rx  | 4    | FTDI TX (橙) |
+| 4                     | SWDIO     |      | N/C          |
+| 5                     | SWCLK     |      | N/C          |
+| 6                     | GND       | 1    | FTDI GND (黑)|
 
-### Connecting via Dronecode Probe
+## Pixhawk v1: Console连线
 
-Connect the 6-pos DF13 1:1 cable on the [Dronecode probe](http://nicadrone.com/index.php?id_product=65&controller=product) to the SERIAL4/5 port of Pixhawk.
+系统console可以通过Dronecode Probe或FTDI线访问。两种方式将在下面介绍。
+
+### 通过Dronecode Probe连接
+
+将 [Dronecode probe](http://nicadrone.com/index.php?id_product=65&controller=product) 的6P DF13 1:1线连接到Pixhawk的SERIAL4/5接口。
 
 ![](images/console/dronecode_probe.jpg)
 
-### Connecting via FTDI 3.3V Cable
+### 通过FTDI 3.3V 线连接
 
-If no Dronecode probe is at hand an FTDI 3.3V (Digi-Key: [768-1015-ND](http://www.digikey.com/product-detail/en/TTL-232R-3V3/768-1015-ND/1836393)) will do as well.
+如果手头没有Dronecode Probe，也可以使用FTDI 3.3V (Digi-Key: [768-1015-ND](http://www.digikey.com/product-detail/en/TTL-232R-3V3/768-1015-ND/1836393)) 。
 
-| Pixhawk 1/2  |         | FTDI    |        |
-| -- | -- | -- | -- |
-|1         | +5V (red)     |         | N/C    |
-|2         | S4 Tx      |         | N/C   |
-|3         | S4 Rx      |         | N/C   |
-|4         | S5 Tx      | 5       | FTDI RX (yellow)   |
-|5         | S5 Rx      | 4       | FTDI TX (orange)   |
-|6         | GND     | 1       | FTDI GND (black)   |
+| Pixhawk 1/2 |           | FTDI |                  |
+| ----------- | --------- | ---- | ---------------- |
+| 1           | +5V (红)  |      | N/C              |
+| 2           | S4 Tx     |      | N/C              |
+| 3           | S4 Rx     |      | N/C              |
+| 4           | S5 Tx     | 5    | FTDI RX (黄)     |
+| 5           | S5 Rx     | 4    | FTDI TX (橙)     |
+| 6           | GND       | 1    | FTDI GND (黑)    |
 
-The connector pinout is shown in the figure below.
+连接器引脚接线如下图所示。
 
 ![](images/console/console_connector.jpg)
 
-The complete wiring is shown below.
+完整的接线如下图所示。
 
 ![](images/console/console_debug.jpg)
 
-## Opening the Console
+## 打开Console
 
-After the console connection is wired up, use the default serial port tool of your choice or the defaults described below:
+Console接线完成后, 使用你选择的默认串口工具或者下面描述的默认工具：
 
 ### Linux / Mac OS: Screen
 
-Install screen on Ubuntu (Mac OS already has it installed):
+Ubuntu下安装screen (Mac OS 已经默认安装了):
 
 <div class="host-code"></div>
 
@@ -77,10 +79,10 @@ Install screen on Ubuntu (Mac OS already has it installed):
 sudo apt-get install screen
 ```
 
-  * Serial: Pixhawk v1 / Pixracer use 57600 baud
-  * Serial: Snapdragon Flight uses 115200 baud
+  * 串口: Pixhawk v1 / Pixracer 使用 57600 波特率
+  * 串行: Snapdragon Flight 使用 115200 波特率
 
-Connect screen at BAUDRATE baud, 8 data bits, 1 stop bit to the right serial port (use `ls /dev/tty*` and watch what changes when unplugging / replugging the USB device). Common names are `/dev/ttyUSB0` and `/dev/ttyACM0` for Linux and `/dev/tty.usbserial-ABCBD` for Mac OS.
+按照 BAUDRATE baud, 8 data bits, 1 stop bit 将screen连接至正确的串口（使用 `ls /dev/tty*`命令，观察在拔下/重插USB设备时什么发生了变化）。Linux下的常见名称是 `/dev/ttyUSB0` 和 `/dev/ttyACM0` ，Mac OS下是`/dev/tty.usbserial-ABCBD`。
 
 <div class="host-code"></div>
 
@@ -90,17 +92,17 @@ screen /dev/ttyXXX BAUDRATE 8N1
 
 ### Windows: PuTTY
 
-Download [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) and start it.
+下载 [PuTTY](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html) 并启动它。
 
-Then select 'serial connection' and set the port parameters to:
+选择“串口连接”，然后设置串口参数：
 
   * 57600 baud
   * 8 data bits
   * 1 stop bit
 
-## Getting Started on the Console
+## Console入门
 
-Type `ls` to view the local file system, type `free` to see the remaining free RAM. The console will also display the system boot log when power-cycling the board.
+输入`ls`查看本地文件系统，输入`free`查看剩余可用RAM。当飞控板带电重启时，console也可以显示系统启动日志。
 
 ```bash
 nsh> ls
@@ -108,38 +110,32 @@ nsh> free
 ```
 
 ## MAVLink Shell
-For NuttX-based systems (Pixhawk, Pixracer, ...), the nsh console can also be
-accessed via mavlink. This works via serial link or WiFi (UDP/TCP). Make sure
-that QGC is not running, then start the shell with e.g.
-`./Tools/mavlink_shell.py /dev/ttyACM0` (in the Firmware source). Use `-h` to
-get a description of all available arguments. You may first have to install the
-dependencies with `sudo pip install pymavlink pyserial`.
+对于基于NuttX的系统（Pixhawk，Pixracer，...），也可以通过mavlink访问nsh console。它通过串口连接或WiFi（UDP/TCP）来工作。确保没有运行QGC，然后使用如下命令启动shell`./Tools/mavlink_shell.py /dev/ttyACM0`（在固件源代码中）。使用`-h`获得所有可用参数的描述。也许你先要使用`sudo pip install pymavlink pyserial`安装依赖文件。
 
 # Snapdragon DSP Console
-When you are connected to your Snapdragon board via usb you have access to the px4 shell on the posix side of things.
-The interaction with the DSP side (QuRT) is enabled with the `qshell` posix app and its QuRT companion.
+当通过USB连接到Snapdragon开发板，你可以访问PX4 shell操作posix相关资源 。与DSP侧（QuRT）的交互可以通过`qshell`posix应用程序及其QuRT companion。
 
-With the Snapdragon connected via USB, open the mini-dm to see the output of the DSP:
+将Snapdragon通过USB连接后，打开mini-dm就可以看到DSP的输出：
 ```
 ${HEXAGON_SDK_ROOT}/tools/debug/mini-dm/Linux_Debug/mini-dm
 ```
 
-Note: Alternatively, especially on Mac, you can also use [nano-dm](https://github.com/kevinmehall/nano-dm).
+注意: 可选方法，尤其是在Mac上,你也可以使用 [nano-dm](https://github.com/kevinmehall/nano-dm)。
 
-Run the main app on the linaro side:
+在linaro侧运行主程序：
 ```
 cd /home/linaro
 ./px4 px4.config
 ```
 
-You can now use all apps loaded on the DSP from the linaro shell with the following syntax:
+你可以通过linaro shell使用DSP加载的所有的应用程序，通过以下语法：
 ```
 pxh> qshell command [args ...]
 ```
 
-For example, to see the available QuRT apps:
+例如，要查看可用QuRT应用程序：
 ```
 pxh> qshell list_tasks
 ```
 
-The output of the executed command is displayed on the minidm.
+所执行命令的输出显示在minidm上。

--- a/advanced-system-startup.md
+++ b/advanced-system-startup.md
@@ -1,53 +1,53 @@
-# System Startup
+# 系统启动
 
-The PX4 boot is controlled by shell scripts in the [ROMFS/px4fmu_common/init.d](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common/init.d) folder.
+PX4 的启动是由存在于[ROMFS/px4fmu_common/init.d](https://github.com/PX4/Firmware/tree/master/ROMFS/px4fmu_common/init.d) 文件夹中的 shell 脚本控制
 
-All files starting with a number and underscore (e.g. `10000_airplane`) are canned airframe configurations. They are exported at build-time into an `airframes.xml` file which is parsed by [QGroundControl](http://qgroundcontrol.com) for the airframe selection UI. Adding a new configuration is covered [here](airframes-adding-a-new-frame.md).
+所有的以数字和下划线（例如 `10000_airplane`）开头的文件都是封装好的机身配置文件。在构建的时候，他们会被导出到一个叫 `airframes.xml` 的文件中，这个文件是被 [QGroundControl](http://qgroundcontrol.com) 解析并为机体选择UI的。 如果你想添加新的配置文件，请点击[这里](airframes-adding-a-new-frame.md)
 
-The remaining files are part of the general startup logic, and the first executed file is the [rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/rcS) script, which calls all other scripts.
+剩下的文件是通用启动逻辑中的一部分，第一个执行的文件是 [rcS](https://github.com/PX4/Firmware/blob/master/ROMFS/px4fmu_common/init.d/rcS) 脚本，它会调用所有的其他脚本。
 
-## Debugging the System Boot
+## 调试模式启动
 
-A failure of a driver of software component can lead to an aborted boot.
+硬件或者软件的故障会导致引导终止。
 
 <aside class="tip">
-An incomplete boot often materializes as missing parameters in the ground control stations, because the non-started applications did not initialize their parameters.
+不完全的启动通常由于地面控制站缺少参数导致的，因为未启动的引用程序没有初始化它们的参数。
 </aside>
 
-The right approach to debug the boot sequence is to connect the [system console](advanced-system-console.md) and power-cycle the board. The resulting boot log has detailed information about the boot sequence and should contain hints why the boot aborted.
+调试引导顺序的正确方法是连接 [系统控制台](advanced-system-console.md) 然后重新对 PX4 上电。在生成的启动日志中记录了详细的启动顺序信息，并应该包含启动中断的原因。
 
-### Common boot failure causes
+### 常见的引导失败原因
 
-  * A required sensor failed to start
-  * For custom applications: The system was out of RAM. Run the `free` command to see the amount of free RAM.
-  * A software fault or assertion resulting in a stack trace
+  * 所需的传感器无法启动
+  * 对于自定义的引用程序：常见的错误是由于内存溢出导致的。运行 `free` 命令来检查系统可用的 RAM 
+  * 软件故障或断言导致的堆栈跟踪
 
-## Replacing the System Startup
+## 更换系统启动
 
-In most cases customizing the default boot is the better approach, which is documented below. If the complete boot should be replaced, create a file `/fs/microsd/etc/rc.txt`, which is located in the `etc` folder on the microSD card. If this file is present nothing in the system will be auto-started.
+在大多数情况下，自定义默认引导是更好的方法。如果想要自定义默认引导，请在 `etc` 文件夹下创建创建一个 `rc.txt` 文件，这个文件可以在 microSD 卡上的文件夹找到。当这个文件不存在的时候，系统会默认自动启动。
 
-## Customizing the System Startup
+## 自定义系统启动
 
-The best way to customize the system startup is to introduce a [new airframe configuration](airframes-adding-a-new-frame.md). If only tweaks are wanted (like starting one more application or just using a different mixer) special hooks in the startup can be used.
+自定义系统启动的最好办法是引入一个[新机身配置文件](airframes-adding-a-new-frame.md). 如果只是想调整配置文件（如启动更多的应用或者使用不同的混控）可以使用特殊的进程钩子。
 
 <aside class="caution">
-The system boot files are UNIX FILES which require UNIX LINE ENDINGS. If editing on Windows use a suitable editor.
+系统启动配置文件是 UNIX 文件，它要求 UNIX 的行结尾。如果使用 Windows 系统来编辑这个文件，请选择一个合适的编辑器。 
 </aside>
 
-There are three main hooks. Note that the root folder of the microsd card is identified by the path `/fs/microsd`.
+一下是三个主要的进程钩子的说明。注意，microSD 卡的根目录文件夹路径为 `/fs/microsd`
 
   * /fs/microsd/etc/config.txt
   * /fs/microsd/etc/extras.txt
   * /fs/microsd/mixers/NAME_OF_MIXER
 
-### Customizing the Configuration (config.txt)
+### 自定义配置（config.txt）
 
-The `config.txt` file is loaded after the main system has been configured and *before* it is booted and allows to modify shell variables.
+该 config.txt 文件在主系统配置完成后并在引导之前加载，并允许修改 shell 变量。
 
-### Starting additional applications
+### 启动其他应用程序
 
-The `extras.txt` can be used to start additional applications after the main system boot. Typically these would be payload controllers or similar optional custom components.
+extras.txt 可用于启动主系统引导后额外的应用程序。通常这些将是有效载荷控制器或类似的可选自定义组件
 
-### Starting a custom mixer
+### 启动自定义混控
 
-By default the system loads the mixer from `/etc/mixers`. If a file with the same name exists in `/fs/microsd/etc/mixers` this file will be loaded instead. This allows to customize the mixer file without the need to recompile the Firmware.
+默认情况下，系统从  `/etc/mixers`  如果一个具有相同文件名的文件存在于  `/fs/microsd/etc/mixers`  那么这个文件将会被载入。通过这个设定，允许用户自定义混控且无需重新编译固件。

--- a/advanced-uorb.md
+++ b/advanced-uorb.md
@@ -1,62 +1,58 @@
-# uORB Messaging
+# uORB 消息机制
 
-## Introduction
+## 简介
 
-The uORB is an asynchronous publish() / subscribe() messaging API used for
-inter-thread/inter-process communication.
+uORB（*微型对象请求代理*）是一个异步的发布／订阅消息机制的 API，用来实现线程或进程间的通讯。 
 
-Look at the [tutorial](tutorial-hello-sky.md) to learn how to use it in C++.
+请参照[教程](tutorial-hello-sky.md) 学习如何在 C++ 中使用该功能。
 
-uORB is automatically started early on bootup as many applications depend on it.
-It is started with `uorb start`. Unit tests can be started with `uorb test`.
+由于很多应用依赖该消息机制，uORB 会在系统启动时自动开始运行。
+ `uorb start` 命令会启动该消息机制。使用 `uorb test` 命令可以启动单元测试。
 
-## Adding a new topic
+## 添加一个新主题
 
-To add a new topic, you need to create a new `.msg` file in the `msg/`
-directory and add the file name to the `msg/CMakeLists.txt` list. From this,
-there will automatically be C/C++ code generated.
+为了添加一个新主题，你需要在 `msg/` 路径下添加一个新的 `.msg` 文件，并将该文件名添加到 `msg/CMakeLists.txt` 列表中。通过以上步骤，系统将会自动生成 C/C++ 代码。
 
-Have a look at the existing `msg` files for supported types. A message can also
-be used nested in other messages.
-To each generated C/C++ struct, a field `uint64_t timestamp` will be added. This
-is used for the logger, so make sure to fill it in when logging the message.
+让我们来看看现有的 `msg` 文件所支持的类型。一条消息可以被嵌套在其他消息内。
+对于每一个生成的 C/C++ 结构，都会包含一个 `uint64_t timestamp` 成员。这个成员会被日志模块使用，所以如果要将消息记录进日志，请确保该成员被赋值。
 
-To use the topic in the code, include the header:
+要在代码中使用该消息，需要包含头文件：
+
 ```
 #include <uORB/topics/topic_name.h>
 ```
 
-By adding a line like the following in the `.msg` file, a single message
-definition can be used for multiple independent topic instances:
+在 `.msg` 文件中添加类似下面这一行，一条单一的消息定义可以被多个独立的主题实例使用。
+
 ```
 # TOPICS mission offboard_mission onboard_mission
 ```
-Then in the code, use them as topic id: `ORB_ID(offboard_mission)`.
+然后在代码中，通过如下的主题 ID 来使用新定义的主题：`ORB_ID(offboard_mission)`.
 
 
-## Publishing
+## 消息发布 (Publishing)
 
-Publishing a topic can be done from anywhere in the system, including interrupt context (functions called by the `hrt_call` API). However, advertising a topic is only possible outside of interrupt context. A topic has to be advertised in the same process as its later published.
+消息发布可以在系统的任何地方实现，包括中断上下文（通过 `hrt_call`  API 调用的函数）。然而公告消息 (advertising) 则只能在中断上下文外部实现。在同一个进程中，一条主题被发布之前，必须先公告。
 
-## Listing Topics and Listening in
 
-<aside class="note">
-The 'listener' command is only available on Pixracer (FMUv4) and Linux / OS X.
+## 主题列表与监听
+
+<aside class="note">'listener'（监听）命令只能在 Pixracer (FMUv4) 和 Linux / OS X 平台上使用。
 </aside>
 
-To list all topics, list the file handles:
+通过列出文件句柄来查看主题列表：
 
 ```sh
 ls /obj
 ```
 
-To listen to the content of one topic for 5 messages, run the listener:
+调用 listener 来监听同一个主题的 5 条消息的内容：
 
 ```sh
 listener sensor_accel 5
 ```
 
-The output is n-times the content of the topic:
+输出为若干次该主题的内容：
 
 ```sh
 TOPIC: sensor_accel #3
@@ -87,3 +83,5 @@ temperature: 46
 range_m_s2: 78
 scaling: 0
 ```
+
+

--- a/airframes-vtol.md
+++ b/airframes-vtol.md
@@ -1,40 +1,39 @@
-# VTOL Airframes
+# 垂直起降(VTOL)机型 
 
-The [PX4 Flight Stack](concept-flight-stack.md) supports virtually all VTOL configurations:
+事实上，[PX4 飞行栈](concept-flight-stack.md) 支持所有类型的垂直起降构型无人机:
 
-  * Tailsitters (duo and quadrotors in X and plus configuration)
-  * Tiltrotors (Firefly Y6)
-  * Standard plane VTOL (plane plus quad)
+  * 尾坐式( X 构型和 十 字构型双旋翼和四旋翼）
+  * 倾转旋翼式 (Firefly 的 Y6)
+  * 常规固定翼垂直起降飞机(Standard Plane VTOL) (固定翼和四旋翼复合式，下文简称复合式)
 
-The VTOL codebase is the same codebase as for all other airframes and just adds additional control logic, in particular for transitions.
+垂直起降机型的代码库和其他机型的代码库是一样的，仅仅增加了对于转换模态的控制逻辑。
 
 <aside class="note">
-All these VTOL configurations have been actively test-flown and are ready to use. Ensure to have an airspeed sensor attached to the system as its used by the autopilot when its safe to perform the transition.
+代码中所有的垂直起降构型都已经经过试飞测试，可以直接使用。为了转换过程的安全进行，请确保飞机上装有空速传感器，因为自动驾驶仪在转换模态需要使用空速信号。
 </aside>
 
-## Key Configuration Parameters
+## 关键设置参数
 
-These configuration parameters have to be set correctly when creating a new airframe configuration.
+当创建一个新的飞机构型时，必须正确设置下列参数：
 
-  * `VT_FW_PERM_STAB` the system always uses attitude stabilization in hover mode. If this parameter is set to 1, the plane mode also defaults to attitude stabilization. If it is set to 0, it defaults to pure manual flight.
-  * `VT_ARSP_TRANS` is the airspeed in m/s at which the plane transitions into forward flight. Setting it too low can cause a stall during the transition.
-  * `RC_MAP_TRANS_SW` should be assigned to a RC switch before flight. This allows you to check if the multicopter- and fixed wing mode work properly. (Can also be used to switch manually between those two control modes during flight)
+  * `VT_FW_PERM_STAB` 在悬停模式中，自驾仪总是使用姿态稳定模式。如果将该参数设置为1，则飞机默认为姿态稳定模式；如果设置为0，则默认纯手动操纵模式。
+  * `VT_ARSP_TRANS` 该参数表示飞机到达多大空速时开始转换到前飞模式，单位为米/秒。若将该参数设置过小，则开始转换时飞机有可能失速。
+  * `RC_MAP_TRANS_SW` 该参数为一个切换信号，必须在飞行前指定到遥控器的一个开关通道。这可以使你能够检查多旋翼模态和固定翼模态是否工作正常。（也可以用来在飞行中手动切换多旋翼模态和固定翼模态）
 
-## Tailsitter
+## 尾坐式
 
-The [build log](airframes-vtol-caipiroshka.md) contains further detail.
-
+[构建日志](airframes-vtol-caipiroshka.md) 包含了更多细节。
 {% youtube %}https://www.youtube.com/watch?v=acG0aTuf3f8&vq=hd720{% endyoutube %}
 
-## Tiltrotor
+## 倾转旋翼式
 
-The [build log](https://pixhawk.org/platforms/vtol/birdseyeview_firefly) contains all settings and instructions to get one of these up and running.
+ [构建日志](https://pixhawk.org/platforms/vtol/birdseyeview_firefly)包含了获得并运行这些模式的所有设置和说明。 
 
 {% youtube %}https://www.youtube.com/watch?v=Vsgh5XnF44Y&vq=hd720{% endyoutube %}
 
-## Standard Plane VTOL
+## 复合式
 
-The [build log](https://pixhawk.org/platforms/vtol/fun_cub_quad_vtol) contains further instructions how to build and reproduce the results below.
+[构建日志](https://pixhawk.org/platforms/vtol/fun_cub_quad_vtol)包含了构建并复现如下视频的进一步说明。 
 
 {% youtube %}https://www.youtube.com/watch?v=4K8yaa6A0ks&vq=hd720{% endyoutube %}
 

--- a/ekf2_log_replay.md
+++ b/ekf2_log_replay.md
@@ -1,29 +1,27 @@
-# EKF2 Log Replay
+# EKF2 飞行记录回放 
 
-This page shows you how you can tune the parameters of the EKF2 estimator by using the replay feature on a real flight log. It is based on the `sdlog2` logger.
+本页面将展示如何通过飞行记录的回放功能来调试EKF2（扩展卡尔曼滤波）估计器，该功能是通过 `sdlog2` 记录器实现的。
 
-## Introduction
+## 介绍 
+开发者可以启用对于EKF2估计器的输入传感器数据进行板载记录的功能。然后通过飞行记录回放对EKF2估计器的参数进行线下调试。本页余下的部分将讲解哪些参数的调试能得益于记录回放功能，并说明如何正确的进行配置。
 
-A developer has the possibility to enable onboard logging of the EKF2 estimator input sensor data. This allows him to tune the parameters of the estimator offline by running a replay on the logged data trying out different sets of parameters. The remainder of this page will explain which parameters have to be set in order to benefit from this feature and how to correctly deploy it.
+## 预备
+*  **EKF2\_REC\_RPL** 设置为1。这将通知EKF2显示针对日志回放的特定消息。
+* **SDLOG\_PRIO\_BOOST** 设置为 {0, 1, 2, 3} 中的的一个数。0意味着板载飞行记录 app 获得默认（低）的调度优先级。低优先级会导致飞行记录信息的丢失。如果你发现你的记录文件出现 'gaps' （信息不连续），然后你可以将 **SDLOG\_PRIO\_BOOST** 提高到最大值3。测试显示不小于2才能避免数据丢失。
 
-## Prerequisites
+## 配置
 
-* set the parameter **EKF2\_REC\_RPL** to 1. This will tell the estimator to publish special replay messages for logging.
-* set the parameter **SDLOG\_PRIO\_BOOST** to a value contained in the set {0, 1, 2, 3}. A value of 0 means that the onboard logging app has a default \(low\) scheduling priority. A low scheduling priority can lead to a loss of logging messages. If you find that your log file contains 'gaps' due to skipped messages then you can increase this parameter to a maximum value of 3. Testing has shown that a minimum value of 2 is required in order to avoid loss of data.
-
-## Deployment
-
-Once you have a real flight log then you can run a replay on it by using the following command in the root directory of your PX4 Firmware
+当你有了一份飞行记录，你可以通过在 PX4 根目录下运行如下命令行来进行记录回放。
 
 ```
 make posix_sitl_replay replay logfile=absolute_path_to_log_file/my_log_file.px4log
 ```
 
-where 'absolute\_path\_to\_log\_file/my\_log\_file.px4log' is a placeholder for the absolute path of the log file you want to run the replay on. Once the command has executed check the terminal for the location and name of the replayed log file.
+其中， 'absolute\_path\_to\_log\_file/my\_log\_file.px4log' 是记录文件所在根目录。该命令将检查记录文件的目录和名字。
 
-## Changing tuning parameters for a replay
+## 估计器器参数获取与调试
 
-You can set the estimator parameter values for the replay in the file **replay\_params.txt** located in the same directory as your replayed log file, e.g. **build\_posix\_sitl\_replay/src/firmware/posix/rootfs/replay\_params.txt**. When running the replay for the first time \(e.g. after a **make clean**\) this file will be auto generated and filled with the default EKF2 parameter values taken from the flight log. After that you can change any EKF2 parameter value by changing the corresponding number in the text file. Setting the noise value for the gyro bias would require the following line.
+你可以在文件 **replay\_params.txt** 中设置回放过程中的 EKF2 估计器参数， **replay\_params.txt** 和你的回放日志文件在同一目录下，比如： **build\_posix\_sitl\_replay/src/firmware/posix/rootfs/replay\_params.txt** 。首次运行回放功能时（比如：使用 **make clean** 命令后）， **replay\_params.txt** 将根据飞行记录自动生成并写入默认的 EKF2 估计器参数。之后，你可以通过改变该txt文件中的相关量来改变对应的 EKF2 参数。设置陀螺仪漂移的噪声值将需要以下命令行：
 
 ```
 EKF2_GB_NOISE 0.001

--- a/optical-flow-outdoors.md
+++ b/optical-flow-outdoors.md
@@ -1,121 +1,122 @@
-# Optical Flow Outdoors
+﻿# 光流的室外应用
 ----------------------------------------------------
 
-This page shows you how to set up the PX4Flow for position estimation and autonomous flight outdoors. Using a LIDAR device is not necessary, but LIDAR does improve performance.
+这个页面将展示如何使用 PX4Flow 来进行位置估计和室外自动飞行。激光雷达（ LIDAR ）不是必要的但是会带来性能提升。
 
-## Selecting LPE Estimator
+## 选择 LPE 估计器
 --------------------------------------------------------
 
-The only estimator that is tested to work with optical flow based autonomous flight outdoors is, LPE.
+经过测试，LPE是唯一一个适用于基于光流的自动飞行的估计器。
 
-Use the `SYS_MC_EST_GROUP = 1` parameter to select the estimator and then reboot.
+使用 `SYS_MC_EST_GROUP = 1` 来选取和重置估计器。
 
 
-## Hardware
+## 硬件
 --------------------------------------------------------
-
 ![](images/hardware/px4flow_offset.png)
 
-*Figure 1: Mounting Coordinate Frame (relevant to parameters below)*
+*图 1：固定坐标系（与后文参数相关）*
 
 ![](images/hardware/px4flow.png)
 
-*Figure 2: PX4Flow optical flow sensor (camera and sonar)*
+*图 2： PX4Flow 光流处理器（摄像头和超声波测距）*
 
-The PX4Flow has to point towards the ground and can be connected using the I2C port on the pixhawk. For best performance make sure the PX4Flow is attached at a good position and is not exposed to vibration. (preferably on the down side of the quad-rotor).
+PX4Flow 需要对准地面并通过 I2C 接口和 pixhawk 连接。为了达到最优性能，请尽可能将 PX4Flow 安装在一个好的位置上并尽量隔震。（推荐放置于四旋翼的下方）
 
-**Note: The default orientation is that the PX4Flow sonar side (+Y on flow) be pointed toward +X on the vehicle (forward). If it is not, you will need to set SENS_FLOW_ROT accordingly.**
+**注意：默认情况下，PX4Flow 的超声波指向（+Y方向）飞行器坐标系的+X方向（前向）。如果不是，你需要根据实际情况设置 SENS_FLOW_ROT 。**
 
 ![](images/hardware/lidarlite.png)
 
-*Figure 3: Lidar Lite*
+*图 3：激光雷达产品：Lidar Lite*
 
-Several LIDAR options exist including the Lidar-Lite (not currently manufacutured) and the sf10a: [sf10a](http://www.lightware.co.za/shop/en/drone-altimeters/33-sf10a.html). For the connection of the LIDAR-Lite please refer to [this](https://pixhawk.org/peripherals/rangefinder?s[]=lidar) page. The sf10a can be connected using a serial cable.
+兼容的的激光雷达模块包括： Lidar-Lite (尚未量产) 和 [sf10a](http://www.lightware.co.za/shop/en/drone-altimeters/33-sf10a.html)。如何连接 LIDAR-Lite 请参考： [此页](https://pixhawk.org/peripherals/rangefinder?s[]=lidar) . sf10a 可以通过串口连接到 PX4 上。
 
 ![](images/hardware/flow_lidar_attached.jpg)
 
-*Figure: PX4Flow/ Lidar-Lite mounting DJI F450*
+*图 : PX4Flow/ Lidar-Lite 安装在 DJI F450 四轴飞行器上*
 
 ![](images/flow/flow_mounting_iris.png)
 
-*Figure: This Iris+ has a PX4Flow attached without a LIDAR, this works with the LPE estimator.*
+*图 ：一架搭载了采用 LPE 估计器的 PX4Flow 模块（无激光雷达）的 Iris+ 四轴飞行器*
 
 ![](images/flow/flow_mounting_iris_2.png)
 
-*Figure: A weather-proof case was constructed for this flow unit. Foam is also used to surround the sonar to reduce prop noise read by the sonar and help protect the camera lens from crashes.*
+*图 ：一种对光流单元的防护方式。同时也有泡沫包住超声波单元以减小超声波单元采集的噪声，泡沫材料还能保护镜头模组。*
 
 
-### Focusing Camera
+### 摄像头对焦
 
-In order to ensure good optical flow quality, it is important to focus the camera on the PX4Flow to the desired height of flight. To focus the camera, put an object with text on (e. g. a book) and plug in the PX4Flow into usb and run QGroundControl. Under the settings menu, select the PX4Flow and you should see a camera image. Focus the lens by unscrewing the set screw and loosening and tightening the lens to find where it is in focus.
+为了保证光流数据的质量，在特定高度处对光流相机进行对焦是非常重要的。对焦时，将一个表面有字的物体（比如一本书）放在地面上，然后通过usb连接 PX4Flow 并运行 QGroundControl。在设置界面里，选择 PX4Flow，你将看到相机画面。通过旋扭调节相机镜头的松紧进而找到焦点位置。
 
-**Note: If you fly above 3m, the camera will be focused at infinity and won't need to be changed for higher flight.**
+**注意：如果飞行高度超过 3 米，相机将对焦于无穷远处，因而飞更高时无需调整焦距。**
 
 ![](images/flow/flow_focus_book.png)
 
-*Figure: Use a text book to focus the flow camera at the height you want to fly, typically 1-3 meters. Above 3 meters the camera should be focused at infinity and work for all higher altitudes.*
+*图 ：使用书来在一定高度对焦相机，高度一般为 1-3 米。超过 3 米，相机将对焦于无穷远*
 
 
 ![](images/flow/flow_focusing.png)
 
-*Figure: The px4flow interface in QGroundControl that can be used for focusing the camera*
+*图 ：QGroundControl中的 px4flow 界面，可以用来对焦相机*
 
-### Sensor Parameters
+### 传感器参数
 
-All the parameters can be changed in QGroundControl
+在 QGroundControl 中可以改变的参数有：
 * SENS_EN_LL40LS
-	Set to 1 to enable lidar-lite distance measurements
+	设置为1时将激活 lidar-lite 测距模块
 * SENS_EN_SF0X
-	Set to 1 to enable lightware distance measurements (e.g. sf02 and sf10a)
+	设置为1时将激活 Lightware 公司的测距模块（比如 sf02 和 sf10a）
 
-## Local Position Estimator (LPE)
+## 局部定位估计器（LPE）
 --------------------------------------------------------
 
-LPE is an Extended Kalman Filter based estimator for position and velocity states. It uses inertial navigation and is similar to the INAV estimator below but it dynamically calculates the Kalman gain based on the state covariance. It also is capable of detecting faults, which is beneficial for sensors like sonar which can return invalid reads over soft surfaces.
+LPE 是一个基于扩展卡尔曼滤波器的状态和速度估计器。它采用惯性导航并且和后文的 INAV 估计器相似，但是 LPE 会基于状态协方差动态地计算卡尔曼增益。LPE 能检测错误数据，这一点对于超声波模块的使用非常有帮助。因为当遇到软表面时，超声波的返回信号可能为空。
 
-### Flight Video Outdoor
-{% youtube %}https://www.youtube.com/watch?v=Ttfq0-2K434{% endyoutube %} 
+### 户外飞行视频
+{% youtube %}https://www.youtube.com/watch?v=Ttfq0-2K434{% endyoutube %}
 
-Below is a plot of the autonomous mission from the outdoor flight video above using optical flow. GPS is not used to estimate the vehicle position but is plotted for a ground truth comparison. The offset between the GPS and flow data is due to the initialization of the estimator from user error on where it was placed. The initial placement is assumed to be at LPE_LAT and LPE_LON (described below).
+
+下面的轨迹点图取自一个使用光流模块的户外自动飞行视频。GPS 数据仅作为对照，并没有在飞控中被使用。GPS 和光流定位的数据之间的差值来源于初始位置的误差。初始位置假设位于 LPE_LAT 和 LPE_LON。
 
 ![](images/lpe/lpe_flow_vs_gps.png)
 
-*Figure 4: LPE based autonomous mission with optical flow and sonar*
+*图 4：基于采用LPE估计器的光流/超声模块的飞行活动数据*
 
 
-### Parameters
+### 参数
 
-The local position estimator will automatically fuse LIDAR and optical flow data when the sensors are plugged in.
+当传感器接入时，LPE 将自动融合激光雷达（LIDAR）和光流传感器的数据。
 
-* LPE_FLOW_OFF_Z - This is the offset of the optical flow camera from the center of mass of the vehicle. This measures positive down and defaults to zero. This can be left zero for most typical configurations where the z offset is negligible.
-* LPE_FLW_XY - Flow standard deviation in meters.
-* LPW_FLW_QMIN - Minimum flow quality to accept measurement.
-* LPE_SNR_Z -Sonar standard deviation in meters.
-* LPE_SNR_OFF_Z - Offset of sonar sensor from center of mass.
-* LPE_LDR_Z - Lidar standard deviation in meters.
-* LPE_LDR_Z_OFF -Offset of lidar from center of mass.
-* LPE_GPS_ON - You won't be able to fly without GPS if LPE_GPS_ON is set to 1. You must disable it or it will wait for GPS altitude to initialize position. This is so that GPS altitude will take precedence over baro altitude if GPS is available.
 
-**NOTE: LPE_GPS_ON must be set to 0 to enable flight without GPS **
+* LPE_FLOW_OFF_Z - 光流相机到飞行器质心的偏移，向下为正，默认为0。对于大部分典型配置可以设置为0。
+* LPE_FLW_XY - 光流测量标准偏差（单位米）。
+* LPW_FLW_QMIN - 测量值被接受时的最低数据质量.
+* LPE_SNR_Z - 超声波测量标准偏差（单位米）。
+* LPE_SNR_OFF_Z - 超声单元到飞行器质心的偏移。
+* LPE_LDR_Z - 激光雷达标准偏差（单位米）。
+* LPE_LDR_Z_OFF - 激光雷达到飞行器质心的偏移。
+* LPE_GPS_ON - 如果 LPE_GPS_ON 设置为1，飞行器将无法在无GPS情况下飞行。无GPS时，该参数必须设为0，否则位置初始化将在等到 GPS 信号后才能进行。这是因为 GPS 高度初始化的优先级高于气压计高度初始化。
 
-### Autonomous Flight Parameters
+**注意：无 GPS 时，LPE_GPS_ON 必须设置为0。**
 
-*Tell the vehicle where it is in the world*
+### 自动飞行参数
 
-* LPE_LAT - The latitude associated with the (0,0) coordinate in the local frame.
-* LPE_LON - The longitude associated with the (0,0) coordinate in the local frame.
+*告诉飞行器自己在那儿*
 
-*Make the vehicle keep a low altitude and slow speed*
+* LPE_LAT - 局部坐标系下，相对于（0,0）的纬度。
+* LPE_LON - 局部坐标系下，相对于（0,0）的经度。
 
-* MPC_ALT_MODE - Set this to 1 to enable terrain follow
-* LPE_T_Z - This is the terrain process noise. If your environment is hilly, set it to 0.1, if it is a flat parking lot etc. set it to 0.01.
-* MPC_XY_VEL_MAX - Set this to 2 to limit leaning
-* MPC_XY_P - Decrease this to around 0.5 to limit leaning
-* MIS_TAKEOFF_ALT - Set this to 2 meters to allow low altitude takeoffs.
+*使飞行器低空低速飞行*
 
-*Waypoints*
+* MPC_ALT_MODE - 设置为1可以激活地形跟随。
+* LPE_T_Z - 这是地形噪声参数，如果环境多山，设为0.1；如果环境地面平整，设为0.01。
+* MPC_XY_VEL_MAX - 设置为2以限制倾斜。
+* MPC_XY_P - 调低为大约0.5以限制倾斜。
+* MIS_TAKEOFF_ALT - 设置为2可以进行低空起飞。
 
-* Create waypoints with altitude 3 meters or below.
-* Do not create flight plans with extremely long distance, expect about 1m drift / 100 m of flight.
+*航点*
 
-**Note: Before your first auto flight, walk the vehicle manually through the flight with the flow sensor to make sure it will trace the path you expect.**
+* 在3米及以下高度创建航点。
+* 不要创建特别长距离的飞行平面，一般情况下每飞100米会产生1米的漂移。
+
+**注意：在你第一次自动飞行时，建议先手动飞一遍航线，以确认光流处理器测量的和预期一致**

--- a/ros-mavros-installation.md
+++ b/ros-mavros-installation.md
@@ -1,62 +1,62 @@
 
 # MAVROS
 
-The [mavros](http://wiki.ros.org/mavros#mavros.2BAC8-Plugins.sys_status) ros package enables MAVLink extendable communication between computers running ROS, MAVLink enabled autopilots, and MAVLink enabled GCS.  While MAVRos can be used to communicate with any MAVLink enabled autopilot this documentation will be in the context of enabling communication between the PX4 flight stack and a ROS enabled companion computer.
+ROS（机器人操作系统）下的 [mavros](http://wiki.ros.org/mavros#mavros.2BAC8-Plugins.sys_status) 包是一个对 MAVLink 协议端的拓展，mavros 可以使运行 ROS 的电脑与支持 MAVLink 的自驾仪或 GCS 相互通信。尽管 mavros 可以与任何支持 MAVLink 的固件交互，但本文只讨论在 PX4 固件下的使用情况。  
 
-## Installation
+## 安装
 
-MAVROS can be installed either from source or binary. Developers working with ROS are advised to use the source installation.
+mavros 包可以通过 apt-get 直接安装可执行文件，也可以编译源码后安装。但我们建议熟悉 ROS 的开发者从源码编译安装 mavros 包。
 
-### Binary installation (Debian / Ubuntu)
 
-Since v0.5 that programs available in precompiled debian packages for x86 and amd64 (x86\_64).
-Also v0.9+ exists in ARMv7 repo for Ubuntu armhf.
-Just use `apt-get` for installation:
+### 直接安装deb包 (Debian / Ubuntu)
+
+mavros 从 v0.5 版本起支持在 x86 和 amd64 下从软件源中直接安装，v0.9 以后的版本更是增加了对 armhf 的支持；因此，简单使用 apt-get 便可以完成 mavros 的安装：
 ```sh
 $ sudo apt-get install ros-indigo-mavros ros-indigo-mavros-extras
 ```
+> 译者注：Ubuntu 16.04 系统下建议使用 apt install 命令代替 apt-get install
 
-### Source installation
-**Dependencies**
+### 源码编译安装
+**依赖库**
 
-This installation assumes you have a catkin workspace located at `~/catkin_ws` If you don't create one with: 
+以下安装过程假定您已经正确建立了一个用于编译 ROS 软件包的 catkin 工作空间，其路径为 `~/catkin_ws`， 建立这个工作空间的方法是：
 ```sh
 $ mkdir -p ~/catkin_ws/src
 $ cd ~/catkin_ws
 $ catkin init
 ```
 
-You will be using the ROS python tools `wstool, rosinstall,and catkin_tools` for this installation. While they may have been installed during your installation of ROS you can also install them with:
+您必须使用 ROS 中的 python 工具 `wstool, rosinstall, 和 catkin_tools` 来进行此次编译及安装，如果之前没有安装过这几款工具，请使用以下命令来安装：
 ```sh
 $ sudo apt-get install python-wstool python-rosinstall-generator python-catkin-tools
 ```
 
-Note that while the package can be built using catkin_make the prefered method is using catkin_tools as it is a more versatile and "friendly" build tool.
+注意，虽然可以使用 catkin_make 编译工作空间，但是我们推荐使用更通用和友好的 catkin_tools 来代替前者。
 
-If this is your first time using wstool you will need to initialize your source space with:
+如果这是你第一次使用 wstool，则需要执行以下命令初始化包目录：
 ```sh
 $ wstool init ~/catkin_ws/src
 ```
 
-Now you are ready to do the build
+现在，一切都已经准备就绪了，请按照以下操作来完成编译：
 ```sh
-    # 1. get source (upstream - released)
+    # 1. 下载 mavros 的 Release 版本源码
 $ rosinstall_generator --upstream mavros | tee /tmp/mavros.rosinstall
-    # alternative: latest source
+    # 备选: 开发版源码
 $ rosinstall_generator --upstream-development mavros | tee /tmp/mavros.rosinstall
 
-    # 2. get latest released mavlink package
-    # you may run from this line to update ros-*-mavlink package
+    # 2. 下载 mavlink 的 Release 版本源码
+    # 备注： 如果以后需要更新 mavlink 的代码，可以从这一行以下执行
 $ rosinstall_generator mavlink | tee -a /tmp/mavros.rosinstall
 
-    # 3. Setup workspace & install deps
+    # 3. 配置工作空间并设置安装路径（实际安装动作将在最后一句 build 命令执行完以后触发）
 $ wstool merge -t src /tmp/mavros.rosinstall
 $ wstool update -t src
 $ rosdep install --from-paths src --ignore-src --rosdistro indigo -y
 
-    # finally - build
+    # 4. 编译
 $ catkin build
 ```
 <aside class="note">
-If you are installing mavros on a raspberry pi, you may get an error related to your os, when running "rosdep install ...". Add "--os=OS_NAME:OS_VERSION " to the rosdep command and replace OS_NAME with your OS name and OS_VERSION with your OS version (e.g. --os=debian:jessie).
+如果你在树莓派中安装 mavros，编译过程可能会产生一个有关你操作系统的错误，解决办法是在 `rosdep install ...` 指令后附加 `--os=OS_NAME:OS_VERSION` 参数，其中 `OS_NAME` 是你系统类型，`OS_VERSION` 是版本号，例如 `--os=debian:jessie`
 </aside>

--- a/starting-initial-config.md
+++ b/starting-initial-config.md
@@ -1,22 +1,22 @@
-# Initial Configuration
+# 初始配置
 
-Before starting to develop on PX4, the system should be configured initially with a default configuration to ensure the hardware is set up properly and is tested. The video below explains the setup process with [Pixhawk hardware](hardware-pixhawk.md) and [QGroundControl](qgroundcontrol-intro.md). A list of supported reference airframes is [here](airframes-architecture.md).
+在开始开发PX4之前，系统应当以默认配置进行初始配置，以确保硬件已经正确配备和测试。下方视频讲解了[Pixhawk硬件](hardware-pixhawk.md)与[QGroundControl](qgroundcontrol-intro.md)的安装过程。[此链接](airframes-architecture.md)为已支持的参考机架列表。
 
-> **Info** [Download the DAILY BUILD of QGroundControl](http://qgroundcontrol.com/downloads) and follow the video instructions below to set up your vehicle. See the [QGroundControl Tutorial](http://dev.px4.io/qgroundcontrol-intro.html) for details on mission planning, flying and parameter setting.
+> **注意** [下载QGroundControl的DAILY BUILD](http://qgroundcontrol.com/downloads)并跟随下方视频教程组装你的飞机。任务规划，飞行与参数设定详见[QGroundControl教程](http://dev.px4.io/qgroundcontrol-intro.html)。
 
-A list of setup options is below the video.
+下面的视频介绍了一些设置选项。
 
-{% youtube %}https://www.youtube.com/watch?v=91VGmdSlbo4&rel=0&vq=hd720{% endyoutube %}
+{% tencentvideo %}https://v.qq.com/x/page/w0376wesku2.html{% endtencentvideo %}
 
-## Radio Control Options
+## 遥控选项
 
-The PX4 flight stack does not mandate a radio control system. It also does not mandate the use of individual switches for selecting flight modes.
+PX4飞行栈并不强制要求有遥控系统。它也不强制要用一个独立的开关来选择飞行模式。
 
-### Flying without Radio Control
+### 无遥控飞行
 
-All radio control setup checks can be disabled by setting the parameter `COM_RC_IN_MODE` to `1`. This will not allow manual flight, but e.g. flying in 
+所有的遥控安装检查可以通过将`COM_RC_IN_MODE`设为`1`来禁用。这将会不允许手动模式飞行， but e.g. flying in 
 
-### Single Channel Mode Switch
+### 单通道模式切换开关
 
-Instead of using multiple switches, in this mode the system accepts a single channel as mode switch. This is explained in the [legacy wiki](https://pixhawk.org/peripherals/radio-control/opentx/single_channel_mode_switch).
+替代使用多个开关的模式，在该模式下，系统接受单个通过作为模式切换开关。在[旧版wiki](https://pixhawk.org/peripherals/radio-control/opentx/single_channel_mode_switch)中对此有解释。
 


### PR DESCRIPTION
# Crazyflie 2.0

Crazyflie 是由Bitcraze AB发起的微型四旋翼飞行器项目. Crazyflie 2 (CF2) 的概述在以下网址: https://www.bitcraze.io/crazyflie-2/

![](images/hardware/hardware-crazyflie2.png)

## 概要

> ** 主要硬件手册网址: https://wiki.bitcraze.io/projects:crazyflie2:index **

  * 主处理器芯片: STM32F405RG
    * CPU: 168 MHz主频  ARM Cortex M4内核  内置单精度浮点处理器
    * RAM: 192 KB SRAM
  * nRF51822 无线通信模块 与 电源管理芯片
  * MPU9250 加速度计 / 陀螺仪/ 磁力计
  * LPS25H 气压计


## 加载程序

设置完 PX4开发环境后, 按照以下步骤在CF2上运行PX4软件程序:

1. 下载PX4源代码 [Bootloader](https://github.com/PX4/Bootloader)

2. 用 `make crazyflie_bl`编译

3. 用 DFU模式运行CF2:
	- 确保初始化时未上电
	- 按住按钮
	- 插入usb端口
	- 一秒后,蓝灯应当开始闪烁并且五秒后闪烁更快
	- 松开按钮

4. 用dfu-util加载bootloader: `sudo dfu-util -d 0483:df11 -a 0 -s 0x08000000 -D crazyflie_bl.bin` 并且当完成时拔出CF2的接口
	- 如果成功完成,  当再次插入接口时，那么黄灯此时应当闪烁

5. 下载固件 [Firmware](https://github.com/PX4/Firmware)

6. 用 `make crazyflie_default upload`编译

7. 当提示插入设备时, 插入CF2: 黄灯开始闪烁代表进入bootloader模式. 然后红灯常亮代表加载程序过程开始.

8. 等待完成

9. 完工! 通过QGC校准传感器信息

##无线通信

板载的nRF模块可以通过蓝牙或者以专有的2.4GHz北欧ESB协议连接到飞控板上

- 推荐使用 [Crazyradio PA](https://www.bitcraze.io/crazyradio-pa/).
- 为了让CF2即刻飞行, Crazyflie手机应用可以通过蓝牙连接

使用官方的Bitcraze **Crazyflie手机应用**

- 通过蓝牙连接
- 通过设置1 or 2来改变模式
- 通过QGC校准传感器信息


通过 **MAVLink**连接

- 使用与GCS兼容的crazyradio PA
- 浏览 [cfbridge](https://github.com/dennisss/cfbridge) 网页以了解如何通过无线以任何的用户协议连接至地面站


## 飞行

{% youtube %}https://www.youtube.com/watch?v=oWk0RRIzF-4{% endyoutube %}
